### PR TITLE
Fix header width and mobile tooltips

### DIFF
--- a/css/esqueleto.css
+++ b/css/esqueleto.css
@@ -101,6 +101,13 @@
   color: #263238;
 }
 
+/* Posiciones por defecto de los tooltips */
+.tooltip-craneo { top: -101px; left: 40px; }
+.tooltip-orbito { top: -110px; right: 40px; }
+.tooltip-orbital { bottom: -136px; left: -500%; transform: translateX(-50%); }
+.tooltip-mandi { top: -136px; left: 550%; transform: translateX(-50%); }
+.tooltip-menton { top: -236px; left: -380px; }
+
 @media (max-width: 700px) {
   .esqueleto-interactivo img {
     max-width: 96vw;
@@ -111,4 +118,10 @@
     padding: 12px 4vw 10px 4vw;
     font-size: 0.97rem;
   }
+  /* Ajustes de posiciones en pantallas pequeñas */
+  .tooltip-craneo { top: -85px; left: 20px; }
+  .tooltip-orbito { top: -90px; right: 20px; }
+  .tooltip-orbital { bottom: -110px; left: -400%; }
+  .tooltip-mandi { top: -110px; left: 380%; }
+  .tooltip-menton { top: -200px; left: -250px; }
 }

--- a/css/header.css
+++ b/css/header.css
@@ -1,6 +1,6 @@
 #main-header {
   position: fixed;
-  width: 100vw;
+  width: 100%;
   top: 0;
   left: 0;
   z-index: 1000;

--- a/css/hero.css
+++ b/css/hero.css
@@ -1,7 +1,7 @@
 #hero {
   position: relative;
   min-height: 70vh;
-  width: 100vw;
+  width: 100%;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/css/responsive.css
+++ b/css/responsive.css
@@ -51,7 +51,7 @@
   .esqueleto-interactivo img,
   #hero {
     max-width: 98vw;
-    width: 100vw;
+    width: 100%;
   }
 
   /* Tooltips más pequeños y adaptados */

--- a/css/servicios.css
+++ b/css/servicios.css
@@ -1,5 +1,5 @@
 .servicios-barra {
-  width: 100vw;
+  width: 100%;
   display: grid;
   grid-template-columns: repeat(5, 1fr);
   gap: 18px;                /* Separación entre recuadros */

--- a/index.html
+++ b/index.html
@@ -116,45 +116,45 @@
     <img src="img/Craneo.png" alt="Esqueleto humano Meraky" />
 
     <!-- Ejemplo 1: tooltip a la derecha -->
-    <div class="punto" style="top: 20%; left: 50%;">
+    <div class="punto punto-craneo" style="top: 20%; left: 50%;">
       <span></span>
-      <div class="tooltip-personalizado" style="top: -101px; left: 40px;">
+      <div class="tooltip-personalizado tooltip-craneo">
         <img src="img/implante-craneo.png" alt="Implante craneal" />
         <h3>Implante Craneal</h3>
         <p>Diseñado a medida en PEEK o PMMA para reconstrucción ósea.</p>
       </div>
     </div>
     <!-- Ejemplo 2: tooltip a la izquierda -->
-    <div class="punto" style="top: 42%; left: 50%;">
+    <div class="punto punto-orbito" style="top: 42%; left: 50%;">
       <span></span>
-      <div class="tooltip-personalizado" style="top: -110px; right: 40px;">
+      <div class="tooltip-personalizado tooltip-orbito" >
         <img src="img/ojito2.png" alt="Implante orbitario" />
         <h3>Implante Orbitario</h3>
         <p>Diseño anatómico para reconstrucción ocular derecha.</p>
       </div>
     </div>
         <!-- Ejemplo 3: tooltip arriba -->
-    <div class="punto" style="top: 55%; left: 45%;">
+    <div class="punto punto-orbital" style="top: 55%; left: 45%;">
       <span></span>
-      <div class="tooltip-personalizado" style="bottom: -136px; left: -500%; transform: translateX(-50%);">
+      <div class="tooltip-personalizado tooltip-orbital">
         <img src="img/ojito.png" alt="Implante orbital" />
         <h3>Implante Orbital</h3>
         <p>Reconstrucción personalizada para zigomaticomalar.</p>
       </div>
     </div>
     <!-- Ejemplo 4: tooltip abajo -->
-    <div class="punto" style="top: 75%; left: 52%;">
+    <div class="punto punto-mandi" style="top: 75%; left: 52%;">
       <span></span>
-      <div class="tooltip-personalizado" style="top: -136px; left: 550%; transform: translateX(-50%);">
+      <div class="tooltip-personalizado tooltip-mandi">
         <img src="img/mandi.png" alt="Implante mandibular personalizado" />
         <h3>Implante Mandibular</h3>
         <p>Diseño 3D exacto para la mandibula.</p>
       </div>
     </div>
     <!-- Ejemplo 5: tooltip abajo derecha -->
-    <div class="punto" style="top: 85%; left: 40%;">
+    <div class="punto punto-menton" style="top: 85%; left: 40%;">
       <span></span>
-      <div class="tooltip-personalizado" style="top: -236px; left: -380px;">
+      <div class="tooltip-personalizado tooltip-menton">
         <img src="img/menton.png" alt="Implante de mentón" />
         <h3>Implantes mandibulares</h3>
         <p>Restauración estética y funcional del mentón.</p>


### PR DESCRIPTION
## Summary
- adjust header/hero/servicios widths to avoid horizontal overflow
- tweak responsive rule in `responsive.css`
- refactor index tooltips to use classes and responsive positions
- add mobile specific tooltip offsets

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686594d28210832dad0b5ee24a83338f