### PR TITLE
Fix tooltip and flow layout on mobile

### DIFF
--- a/css/esqueleto.css
+++ b/css/esqueleto.css
@@ -107,10 +107,6 @@
 .tooltip-orbital { bottom: -136px; left: -500%; transform: translateX(-50%); }
 .tooltip-mandi { top: -136px; left: 220%; transform: translateX(-50%); }
 .tooltip-menton { top: -236px; left: -380px; }
-
-.tooltip-menton { top: -236px; left: -380px; }
-
-47wv3r-codex/new-task
 @media (max-width: 700px) {
   .esqueleto-interactivo img {
     max-width: 96vw;
@@ -125,6 +121,16 @@
   .tooltip-craneo { top: -85px; left: 20px; }
   .tooltip-orbito { top: -90px; right: 20px; }
   .tooltip-orbital { bottom: -110px; left: -400%; }
-  .tooltip-mandi { top: -110px; left: 150%; }
-  .tooltip-menton { top: -200px; left: 50px; }
+  .tooltip-mandi {
+    top: auto;
+    bottom: 110%;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+  .tooltip-menton {
+    top: auto;
+    bottom: 120%;
+    left: 50%;
+    transform: translateX(-50%);
+  }
 }

--- a/css/responsive.css
+++ b/css/responsive.css
@@ -121,8 +121,9 @@
   .flujo-circular h2 { font-size: 1.4rem; }
 }
 @media (max-width: 650px) {
-  .circle-flow { gap: 13px 6px; }
-  .circle-item { width: 90px; height: 90px; padding-bottom: 0;}
+  .circle-flow { gap: 20px 16px; }
+  .circle-item { width: 90px; height: 90px; padding-bottom: 0; }
+  .circle-item.abajo { margin-top: 260px; }
   .img-etapa-circ { width: 30px; height: 30px; }
   .circle-num { width: 16px; height: 16px; font-size: 0.75rem; top: 2px; right: 5px; }
 }


### PR DESCRIPTION
## Summary
- adjust mobile tooltip placement for mandibular and menton points
- tweak circle flow spacing for small screens
- clean stray text in tooltip styles

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6867ed024834832d86934c4fadbdaaa8