### PR TITLE
Fix circle overlap on mobile

### DIFF
--- a/css/responsive.css
+++ b/css/responsive.css
@@ -184,4 +184,9 @@
   .item6 {
     margin-top: 500px;
   }
+  /* Raise center circle slightly so it doesn't overlap items 5 and 6 */
+  .circle-center {
+    top: 45%;
+    transform: translate(-50%, -50%);
+  }
 }


### PR DESCRIPTION
## Summary
- adjust circle-center position in mobile layout to avoid overlap with items 5 and 6

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6867f53373a8832d8b6ff2c520a15907