### PR TITLE
Fix mobile header logo offset

### DIFF
--- a/css/header.css
+++ b/css/header.css
@@ -15,6 +15,7 @@
 #main-header.scrolled {
   background: #2d97b8;
   box-shadow: 0 2px 10px rgba(0,0,0,0.11);
+  height: auto;
 }
 
 /* HEADER GENERAL */


### PR DESCRIPTION
## Summary
- correct spacing when the main header becomes sticky by letting it size to content

## Testing
- `npx htmlhint index.html` *(fails: package install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6867f9d41358832dbb8bd0ff4be414b1