### PR TITLE
Fix header scroll error for pages without main-header

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,7 @@
 // Header cambia de transparente a azul al hacer scroll
 window.addEventListener('scroll', function() {
   const header = document.getElementById('main-header');
+  if (!header) return;
   if (window.scrollY > 50) {
     header.classList.add('scrolled');
   } else {


### PR DESCRIPTION
## Summary
- prevent JavaScript errors when pages lack a `main-header` element by checking for null

## Testing
- `node -c js/main.js`

------
https://chatgpt.com/codex/tasks/task_e_68682c209864832d9e3745b84b8703c4