### PR TITLE
Remove redundant component CSS links

### DIFF
--- a/materiales.html
+++ b/materiales.html
@@ -6,7 +6,6 @@
   <title>Materiales - Meraky</title>
   <link rel="icon" href="img/favicon.png" type="image/png">
   <link rel="stylesheet" href="css/style.css">
-  <link rel="stylesheet" href="css/materiales.css">
 </head>
 <body>
 

--- a/sobre-nosotros.html
+++ b/sobre-nosotros.html
@@ -6,7 +6,6 @@
   <title>Sobre Nosotros - Meraky</title>
   <link rel="icon" type="image/png" href="img/favicon.png">
   <link rel="stylesheet" href="css/style.css">
-  <link rel="stylesheet" href="css/sobre-nosotros.css">
 </head>
 <body>
     <header class="header-azul">


### PR DESCRIPTION
## Summary
- remove individual component `<link>` tags from *materiales* and *sobre-nosotros* pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68682c254538832d8fcddefd74b8f66d