### PR TITLE
Fix ampersand encoding in URLs

### DIFF
--- a/consultoria.html
+++ b/consultoria.html
@@ -49,7 +49,7 @@
         <a href="https://maps.app.goo.gl/mAawoEfUnV61vtST7" target="_blank" title="Ubicación">
           <img src="img/facebook-icon.png" alt="Ubicación" style="height: 24px; margin: 0 8px;" />
         </a>
-        <a href="https://www.instagram.com/meraky62018?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw==" target="_blank" title="Instagram">
+        <a href="https://www.instagram.com/meraky62018?utm_source=ig_web_button_share_sheet&amp;igsh=ZDNlZDc0MzIxNw==" target="_blank" title="Instagram">
           <img src="img/instagram-icon.png" alt="Instagram" style="height: 24px; margin: 0 8px;" />
         </a>
         <a href="https://wa.me/57317568720" target="_blank" title="WhatsApp">

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>Meraky - Soluciones a la medida</title>
   <link rel="icon" type="image/png" href="img/favicon.png">
   <!-- Google Fonts: Montserrat -->
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&amp;display=swap" rel="stylesheet">
   
   <!-- SEO Básico -->
   <meta name="description" content="Meraky ofrece implantes personalizados a la medida, planificación quirúrgica y soluciones innovadoras en materiales como PEEK y PMMA.">

--- a/sobre-nosotros.html
+++ b/sobre-nosotros.html
@@ -101,7 +101,7 @@
         <a href="https://maps.app.goo.gl/mAawoEfUnV61vtST7" target="_blank" title="Ubicación">
           <img src="img/facebook-icon.png" alt="Ubicación" style="height: 24px; margin: 0 8px;" />
         </a>
-        <a href="https://www.instagram.com/meraky62018?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw==" target="_blank" title="Instagram">
+        <a href="https://www.instagram.com/meraky62018?utm_source=ig_web_button_share_sheet&amp;igsh=ZDNlZDc0MzIxNw==" target="_blank" title="Instagram">
           <img src="img/instagram-icon.png" alt="Instagram" style="height: 24px; margin: 0 8px;" />
         </a>
         <a href="https://wa.me/57317568720" target="_blank" title="WhatsApp">


### PR DESCRIPTION
## Summary
- escape ampersands in URL query strings to satisfy HTML validators

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68682c312fa0832d9c5e2346c88f9f42