### PR TITLE
Fix mobile circle flow alignment

### DIFF
--- a/css/responsive.css
+++ b/css/responsive.css
@@ -86,15 +86,15 @@
     justify-content: center;
     gap: 12px;
   }
-  /* Raise center circle slightly so it doesn't overlap items 5 and 6 */
+  /* Raise center circle slightly for smaller screens */
   .circle-center {
     width: 90px;
     height: 90px;
     font-size: 0.83rem;
     padding: 7px;
   }
-  .circle-item.item5,
-  .circle-item.item6 { margin-top: 360px; }
+  /* unify margin of all bottom items */
+  .circle-item.abajo { margin-top: 260px; }
 }
 
 /* ---- Ajustes mínimos para pantallas MUY pequeñas ---- */


### PR DESCRIPTION
## Summary
- unify margin for all items in the circular flow on screens below 700px
- remove item-specific rules that misaligned item5 and item6

## Testing
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686bdf53a908832dafac2fbdeed77da3