### PR TITLE
Fix mobile layout for circular flow

### DIFF
--- a/css/responsive.css
+++ b/css/responsive.css
@@ -104,23 +104,6 @@
   padding-top: 0 !important;
 }
 
-@media (max-width: 950px) {
-  .circle-item { width: 130px; height: 130px; }
-  .img-etapa-circ { width: 45px; height: 45px; }
-  .circle-center { width: 130px; height: 130px; font-size: 0.95rem; }
-  .flujo-circular h2 { font-size: 1.4rem; }
-}
-@media (max-width: 650px) {
-  .circle-flow { gap: 20px 16px; }
-  .circle-item { width: 90px; height: 90px; padding-bottom: 0; }
-  .circle-item.abajo { margin-top: 260px; }
-  .img-etapa-circ { width: 30px; height: 30px; }
-  .circle-num { width: 16px; height: 16px; font-size: 0.75rem; top: 2px; right: 5px; }
-  .circle-center { width: 90px; height: 90px; font-size: 0.83rem; padding: 7px; }
-}
-@media (max-width: 500px) {
-  .flujo-circular { margin-top: 24vw; }
-}
 
 @media (max-width: 900px) {
   .header-content {
@@ -165,11 +148,61 @@
   .contenido-servicio h3 {
     font-size: 0.89rem;
   }
-  /* Flujo circular más compacto para móviles muy pequeños */
-  .circle-flow { gap: 12px 10px; }
-  .circle-item { width: 72px; height: 72px; }
-  .img-etapa-circ { width: 28px; height: 28px; }
-  .circle-num { width: 14px; height: 14px; font-size: 0.7rem; top: 2px; right: 4px; }
-  .circle-item.abajo { margin-top: 230px; }
-  .circle-center { width: 80px; height: 80px; font-size: 0.8rem; }
+}
+@media (max-width: 650px) {
+  .circle-item {
+    width: 100px;
+    height: 100px;
+    padding-bottom: 0;
+  }
+  .img-etapa-circ {
+    width: 36px;
+    height: 36px;
+  }
+  .circle-num {
+    width: 18px;
+    height: 18px;
+    font-size: 0.8rem;
+    top: 3px;
+    right: 6px;
+  }
+  .circle-center {
+    width: 100px;
+    height: 100px;
+    font-size: 0.88rem;
+    padding: 6px;
+  }
+  .circle-item.item5,
+  .circle-item.item6,
+  .circle-item.item7 {
+    margin-top: 320px;
+  }
+}
+
+@media (max-width: 430px) {
+  .circle-item {
+    width: 80px;
+    height: 80px;
+  }
+  .img-etapa-circ {
+    width: 28px;
+    height: 28px;
+  }
+  .circle-num {
+    width: 14px;
+    height: 14px;
+    font-size: 0.7rem;
+    top: 2px;
+    right: 4px;
+  }
+  .circle-center {
+    width: 84px;
+    height: 84px;
+    font-size: 0.78rem;
+  }
+  .circle-item.item5,
+  .circle-item.item6,
+  .circle-item.item7 {
+    margin-top: 280px;
+  }
 }


### PR DESCRIPTION
## Summary
- rebuild responsive styles for the circular flow in planeación
- remove old rules that caused overlaps
- add new breakpoints so items 5‑7 sit lower on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c279bc0c4832d936904c74eae84ba