### PR TITLE
Fix ortopedia image layout

### DIFF
--- a/ortopedia.html
+++ b/ortopedia.html
@@ -35,11 +35,11 @@
   <main>
     <h1>Implantes ortopédicos personalizados</h1>
 
-    <div class="seccion-flex">
-      <div class="img-col">
-        <img loading="lazy" src="img/ortopedia.jpg" alt="Implante ortopédico" />
+    <div style="display: flex; flex-wrap: wrap; gap: 30px; align-items: flex-start; justify-content: center; margin-top: 60px;">
+      <div style="flex: 1; min-width: 300px; max-width: 500px;">
+        <img loading="lazy" src="img/ortopedia.jpg" alt="Implante ortopédico" style="width: 100%; border-radius: 10px;" />
       </div>
-      <div class="texto-col">
+      <div style="flex: 1; min-width: 300px;">
         <p>
           En Meraky estamos desarrollando implantes ortopédicos a la medida para diferentes áreas del cuerpo,
           buscando siempre una integración funcional, resistencia mecánica óptima y materiales biocompatibles.


### PR DESCRIPTION
## Summary
- tweak layout in `ortopedia.html` so the image appears on the left in a fixed-width box and text on the right

## Testing
- `tidy -q -e ortopedia.html`

------
https://chatgpt.com/codex/tasks/task_e_686ff12a03e4832da7427b559f320a30