### PR TITLE
Center intro heading in materiales

### DIFF
--- a/materiales.html
+++ b/materiales.html
@@ -34,17 +34,17 @@
 
 <main>
 <section class="intro-materiales">
+  <h2 class="titulo-materiales">Materiales biocompatibles de alta calidad</h2>
   <div class="seccion-flex">
     <div class="texto-col">
-      <h2 class="titulo-materiales">Materiales biocompatibles de alta calidad</h2>
-      <p>Con Meraky, eliges un aliado que no solo fabrica implantes, sino que construye confianza a través de la calidad, la seguridad y el respaldo científico.</p>
+      <p>Con Meraky, eliges un aliado que no solo fabrica implantes, sino que construye confianza a través de la calidad, la seguridad y el respaldo&nbsp;científico.</p>
       <p>Nuestros implantes a la medida se fabrican con materias primas de origen certificado que cumplen con los estándares internacionales más exigentes, incluyendo:</p>
       <ul class="lista-certificaciones">
         <li>ISO 13485</li>
         <li>FDA</li>
         <li>RoHS</li>
       </ul>
-      <p>Reafirmando nuestro compromiso con la excelencia y la legalidad, cumplimos estrictamente con toda la regulación colombiana vigente para dispositivos médicos. Esto te brinda la certeza de que cada implante Meraky no solo es innovador y preciso, sino también seguro y conforme a la normativa local.</p>
+      <p>Reafirmando nuestro compromiso con la excelencia y la legalidad, cumplimos estrictamente con toda la regulación colombiana vigente para dispositivos médicos. Esto te brinda la certeza de que cada implante Meraky no solo es innovador y preciso, sino también seguro y conforme a la normativa&nbsp;local.</p>
     </div>
     <div class="img-col">
       <img loading="lazy" src="img/tabla.png" alt="Tabla de materiales">


### PR DESCRIPTION
## Summary
- move the introductory heading out of the text column so it spans across the intro section

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68702e1845e4832d94cac66243a91186