### PR TITLE
Fix tooltip image responsiveness

### DIFF
--- a/css/esqueleto.css
+++ b/css/esqueleto.css
@@ -69,6 +69,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  box-sizing: border-box;
 }
 
 /* Cuando activo (hover, focus o touch), aparece */
@@ -86,8 +87,8 @@
 }
 
 .tooltip-personalizado img {
-  width: 180px;
-  height: 180px;
+  max-width: 100%;
+  height: auto;
   object-fit: contain;
   border-radius: 10px;
   margin-bottom: 12px;

--- a/css/responsive.css
+++ b/css/responsive.css
@@ -61,8 +61,8 @@
     font-size: 0.97rem;
   }
   .tooltip-personalizado img {
-    width: 95px !important;
-    height: 95px !important;
+    max-width: 100% !important;
+    height: auto !important;
   }
 
   /* Hero: tamaño del texto más pequeño */
@@ -142,8 +142,8 @@
     padding: 8px 1vw 8px 1vw;
   }
   .tooltip-personalizado img {
-    width: 64px !important;
-    height: 64px !important;
+    max-width: 100% !important;
+    height: auto !important;
   }
   .contenido-servicio h3 {
     font-size: 0.89rem;


### PR DESCRIPTION
## Summary
- ensure tooltip images use box-sizing
- allow tooltip images to scale in esqueleto.css
- keep tooltip images responsive in responsive.css

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68752e8221e0832dbc44b45c5501c5d4