### PR TITLE
Restore original skeleton layout

### DIFF
--- a/css/esqueleto.css
+++ b/css/esqueleto.css
@@ -1,22 +1,15 @@
 .esqueleto-interactivo {
   position: relative;
-  width: 98vw;
-  max-width: 560px;
-  margin: 0 auto;
-}
-
-.esqueleto-interactivo::before {
-  content: "";
-  display: block;
-  padding-bottom: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 430px;
 }
 
 .esqueleto-interactivo img {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+  width: 98vw;
+  max-width: 560px;
+  height: auto;
   display: block;
 }
 
@@ -28,7 +21,6 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  transform: translate(-50%, -50%);
 }
 
 .punto span {
@@ -69,7 +61,6 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  box-sizing: border-box;
 }
 
 /* Cuando activo (hover, focus o touch), aparece */
@@ -87,8 +78,8 @@
 }
 
 .tooltip-personalizado img {
-  max-width: 100%;
-  height: auto;
+  width: 180px;
+  height: 180px;
   object-fit: contain;
   border-radius: 10px;
   margin-bottom: 12px;
@@ -117,8 +108,8 @@
 .tooltip-mandi { top: -136px; left: 220%; transform: translateX(-50%); }
 .tooltip-menton { top: -236px; left: -380px; }
 @media (max-width: 700px) {
-  .esqueleto-interactivo {
-    width: 96vw;
+  .esqueleto-interactivo img {
+    max-width: 96vw;
   }
   .tooltip-personalizado {
     min-width: 158px;

--- a/css/responsive.css
+++ b/css/responsive.css
@@ -47,7 +47,7 @@
 @media (max-width: 700px) {
 
   /* Imagen hero y esqueleto: máximo ancho */
-  .esqueleto-interactivo,
+  .esqueleto-interactivo img,
   #hero {
     max-width: 98vw;
     width: 100%;
@@ -61,8 +61,8 @@
     font-size: 0.97rem;
   }
   .tooltip-personalizado img {
-    max-width: 100% !important;
-    height: auto !important;
+    width: 95px !important;
+    height: 95px !important;
   }
 
   /* Hero: tamaño del texto más pequeño */
@@ -142,8 +142,8 @@
     padding: 8px 1vw 8px 1vw;
   }
   .tooltip-personalizado img {
-    max-width: 100% !important;
-    height: auto !important;
+    width: 64px !important;
+    height: 64px !important;
   }
   .contenido-servicio h3 {
     font-size: 0.89rem;


### PR DESCRIPTION
## Summary
- undo skeleton positioning changes
- revert responsive image sizing for tooltips

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687558f8921c832daa101e2d82953010