### PR TITLE
Fix skull hotspot alignment

### DIFF
--- a/css/esqueleto.css
+++ b/css/esqueleto.css
@@ -1,14 +1,13 @@
+
 .esqueleto-interactivo {
   position: relative;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  min-height: 430px;
+  width: 98vw;
+  max-width: 560px;
+  margin: 0 auto;
 }
 
 .esqueleto-interactivo img {
-  width: 98vw;
-  max-width: 560px;
+  width: 100%;
   height: auto;
   display: block;
 }
@@ -18,6 +17,7 @@
   width: 28px;
   height: 28px;
   z-index: 10;
+  transform: translate(-50%, -50%);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -108,6 +108,9 @@
 .tooltip-mandi { top: -136px; left: 220%; transform: translateX(-50%); }
 .tooltip-menton { top: -236px; left: -380px; }
 @media (max-width: 700px) {
+  .esqueleto-interactivo {
+    width: 96vw;
+  }
   .esqueleto-interactivo img {
     max-width: 96vw;
   }


### PR DESCRIPTION
## Summary
- align `.esqueleto-interactivo` container with the image so absolute hotspots scale correctly
- center hotspots with `transform: translate(-50%, -50%)`
- tweak mobile width

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6875769d2c58832dbe072a912c3613ed