### PR TITLE
Add navigation between services pages

### DIFF
--- a/craneales.html
+++ b/craneales.html
@@ -76,6 +76,12 @@
       <div class="swiper-pagination"></div>
     </div>
   </main>
+  <!-- Navegación lateral -->
+  <div class="servicios-nav">
+    <a href="planeacion.html" class="nav-arrow left" aria-label="Ir a Planeación" data-tooltip="Ir a Planeación">&#10094;</a>
+    <a href="maxilofaciales.html" class="nav-arrow right" aria-label="Ir a Maxilofaciales" data-tooltip="Ir a Maxilofaciales">&#10095;</a>
+  </div>
+  <!-- Fin navegación lateral -->
 
   <footer>
     <div class="footer-content">

--- a/css/navegacion-servicios.css
+++ b/css/navegacion-servicios.css
@@ -1,0 +1,46 @@
+/* === Navegación lateral servicios === */
+.servicios-nav {
+  position: relative; /* contexto para tooltips */
+}
+.servicios-nav .nav-arrow {
+  position: fixed;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 48px;
+  height: 48px;
+  background: #2d97b8;
+  color: #fff;
+  border-radius: 50%;
+  text-align: center;
+  line-height: 48px;
+  font-size: 1.8rem;
+  text-decoration: none;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+  z-index: 1000;
+}
+.servicios-nav .nav-arrow.left {
+  left: 10px;
+}
+.servicios-nav .nav-arrow.right {
+  right: 10px;
+}
+.servicios-nav .nav-arrow:hover::after,
+.servicios-nav .nav-arrow:focus::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0,0,0,0.75);
+  color: #fff;
+  padding: 4px 8px;
+  border-radius: 4px;
+  white-space: nowrap;
+  font-size: 0.75rem;
+}
+/* -- Ajustes responsivos -- */
+@media (hover: none) {
+  .servicios-nav .nav-arrow:hover::after {
+    display: none;
+  }
+}

--- a/css/style.css
+++ b/css/style.css
@@ -1,3 +1,4 @@
+@import url('navegacion-servicios.css');
 @import url('header.css');
 @import url('hero.css');
 @import url('servicios.css');

--- a/maxilofaciales.html
+++ b/maxilofaciales.html
@@ -121,6 +121,12 @@
     </div>
   </section>
 </main>
+  <!-- Navegación lateral -->
+  <div class="servicios-nav">
+    <a href="craneales.html" class="nav-arrow left" aria-label="Ir a Craneales" data-tooltip="Ir a Craneales">&#10094;</a>
+    <a href="veterinarios.html" class="nav-arrow right" aria-label="Ir a Veterinarios" data-tooltip="Ir a Veterinarios">&#10095;</a>
+  </div>
+  <!-- Fin navegación lateral -->
 
   <footer>
     <div class="footer-content">

--- a/ortopedia.html
+++ b/ortopedia.html
@@ -63,6 +63,11 @@
       <div class="swiper-pagination"></div>
     </div>
   </main>
+  <!-- Navegación lateral -->
+  <div class="servicios-nav">
+    <a href="veterinarios.html" class="nav-arrow left" aria-label="Ir a Veterinarios" data-tooltip="Ir a Veterinarios">&#10094;</a>
+  </div>
+  <!-- Fin navegación lateral -->
 
   <footer>
     <div class="footer-content">

--- a/planeacion.html
+++ b/planeacion.html
@@ -119,6 +119,11 @@
     <div class="swiper-pagination"></div>
   </div>
 </main>
+  <!-- Navegación lateral -->
+  <div class="servicios-nav">
+    <a href="craneales.html" class="nav-arrow right" aria-label="Ir a Craneales" data-tooltip="Ir a Craneales">&#10095;</a>
+  </div>
+  <!-- Fin navegación lateral -->
 
 <footer>
   <div class="footer-content">

--- a/veterinarios.html
+++ b/veterinarios.html
@@ -76,6 +76,12 @@
       <div class="swiper-pagination"></div>
     </div>
   </main>
+  <!-- Navegación lateral -->
+  <div class="servicios-nav">
+    <a href="maxilofaciales.html" class="nav-arrow left" aria-label="Ir a Maxilofaciales" data-tooltip="Ir a Maxilofaciales">&#10094;</a>
+    <a href="ortopedia.html" class="nav-arrow right" aria-label="Ir a Ortopedia" data-tooltip="Ir a Ortopedia">&#10095;</a>
+  </div>
+  <!-- Fin navegación lateral -->
 
   <footer>
     <div class="footer-content">


### PR DESCRIPTION
## Summary
- style navigation arrows for service pages
- import `navegacion-servicios.css` from `style.css`
- add lateral navigation block to each service page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68765c9eaa58832d9696427d4dae5ae9